### PR TITLE
Added UUIDChecker back into the project.

### DIFF
--- a/ponder-bukkit/src/main/kotlin/preponderous/ponder/minecraft/bukkit/uuid/UUIDChecker.java
+++ b/ponder-bukkit/src/main/kotlin/preponderous/ponder/minecraft/bukkit/uuid/UUIDChecker.java
@@ -1,0 +1,72 @@
+/*
+  Copyright (c) 2022 Preponderous Software
+  MIT License
+ */
+package preponderous.ponder.minecraft.bukkit.tools;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+/**
+ * @author Daniel McCoy Stephenson
+ * @author Pasarus
+ * @author Callum Johnson
+ */
+public class UUIDChecker {
+
+    /**
+     * Method to obtain the name of a player based on their UUID.
+     * <p>
+     *     This method utilises {@link Bukkit#getOfflinePlayer(UUID)} and {@link Bukkit#getPlayer(UUID)} to obtain the
+     *     player object, to then uses {@link OfflinePlayer} and {@link Player} to obtain the <em>known</em> name for
+     *     that player.
+     * </p>
+     *
+     * @param playerUUID used to find the name.
+     * @return Name of the player as a {@link String}
+     * @throws IllegalArgumentException if the UUID provided is null.
+     */
+    public String findPlayerNameBasedOnUUID(UUID playerUUID) {
+        if (playerUUID == null) {
+            throw new IllegalArgumentException("Player UUID cannot be null!");
+        }
+        final Player player = Bukkit.getPlayer(playerUUID);
+        if (player != null) {
+            return player.getName();
+        }
+        final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(playerUUID);
+        final String name = offlinePlayer.getName();
+        return name == null || !offlinePlayer.hasPlayedBefore() ? "" : name;
+    }
+
+    /**
+     * Method to obtain the UUID of a player based on their <em>known</em> name.
+     * <p>
+     *     This method utilises {@link Bukkit#getOfflinePlayer(String)} and {@link Bukkit#getPlayer(String)} to obtain
+     *     the player object, to then uses {@link OfflinePlayer} and {@link Player} to obtain UUID for that player.
+     *     <br>
+     *     As of 1.8, UUID are the only <em>accurate</em> way of identifying a player, therefore, the existing
+     *     methodology to obtain players by name etc. etc. are deprecated.
+     * </p>
+     *
+     * @param playerName used to find the UUID.
+     * @return {@link UUID} (Unique ID) of the Player.
+     * @throws IllegalArgumentException if the name is null.
+     */
+    @SuppressWarnings("deprecation")
+    public UUID findUUIDBasedOnPlayerName(String playerName) {
+        if (playerName == null) {
+            throw new IllegalArgumentException("Player Name cannot be null!");
+        }
+        final Player player = Bukkit.getPlayer(playerName);
+        if (player != null) {
+            return player.getUniqueId();
+        }
+        final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(playerName);
+        final String name = offlinePlayer.getName();
+        return name == null || !offlinePlayer.hasPlayedBefore() ? null : offlinePlayer.getUniqueId();
+    }
+}


### PR DESCRIPTION
In times when a player's UUID needs to be found from their name (or their name from their UUID), this class comes very much in handy. This is used across a lot of my plugins, so I want to include it in the next version of Ponder. I am open to feedback regarding the design/implementation, however.