### PR TITLE
docs: fix broken code examples and stale references

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -38,7 +38,12 @@ The standard `Cache` implementation backed by a `LinkedHashMap`. Accepts a `Cach
 
 ### `CacheManager` (interface)
 
-Manages a collection of named caches.
+Creates `Cache` instances from a name/type or a `CacheConfiguration`.
+
+| Method | Description |
+|--------|-------------|
+| `createCache(String name, Class<K> keyType, Class<V> valueType, long capacity)` | Creates a new cache with the given name, key/value types, and capacity. |
+| `createCache(CacheConfiguration<K, V> config)` | Creates a new cache using the given configuration. |
 
 ### `DefaultCacheManager`
 
@@ -58,7 +63,12 @@ Abstraction for the entity that sends a command (e.g. a player or console).
 
 ### `Args`
 
-Wrapper around the raw argument string passed to a command. Provides helpers for parsing positional arguments.
+Extension functions on `Array<out String>` for working with raw command argument arrays (there is no `Args` wrapper class).
+
+| Function | Description |
+|----------|-------------|
+| `Array<out String>.dropFirst()` | Returns a new array with the first element removed. |
+| `Array<out String>.unquote()` | Merges quoted, space-separated arguments (e.g. `"hello world"`) back into single elements. |
 
 ### `CommandResult` (sealed class / interface)
 
@@ -70,7 +80,12 @@ A `CommandResult` subtype indicating that the command was invoked with invalid a
 
 ### `CommandService` (interface)
 
-Accepts raw command input and dispatches it to the appropriate `Command` implementation.
+A registry of named `Command` implementations. It does not dispatch commands itself — callers look up a command by name and call its `execute` method (see `DelegatingCommand` for automatic sub-command routing).
+
+| Method | Description |
+|--------|-------------|
+| `addCommand(String name, Command command)` | Registers a command under the given name. |
+| `getCommand(String name)` | Returns the command registered under the given name, or `null`. |
 
 ### `DefaultCommandService`
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -49,5 +49,6 @@ CacheConfiguration<UUID, PlayerData> smallConfig =
 CacheConfiguration<UUID, PlayerData> largeConfig =
     new CacheConfiguration<>("player-data", 1000);
 
-Cache<UUID, PlayerData> cache = new DefaultCache<>(largeConfig);
+CacheManager cacheManager = new DefaultCacheManager();
+Cache<UUID, PlayerData> cache = cacheManager.createCache(largeConfig);
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,13 +38,13 @@ Issues are grouped into [milestones](https://github.com/Dans-Plugins/Ponder/mile
 ## Making Changes
 
 1. Make sure an issue exists for the work. If not, create one.
-2. Switch to `develop`: `git checkout develop`
+2. Switch to `main`: `git checkout main`
 3. Create a branch: `git checkout -b <branch-name>`
 4. Make your changes.
 5. Test your changes (see [Testing](#testing)).
 6. Commit: `git commit -m "Description of changes"`
 7. Push: `git push origin <branch-name>`
-8. Open a pull request against `develop`, link the related issue with `#<number>`.
+8. Open a pull request against `main`, link the related issue with `#<number>`.
 9. Address review feedback.
 
 ## Testing

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -24,10 +24,11 @@ Add the desired Ponder module(s) to your project by following the [Installation]
    CacheConfiguration<String, MyObject> config = new CacheConfiguration<>("my-cache", 100);
    ```
 
-2. Create a `DefaultCache` backed by that configuration:
+2. Create a `Cache` from a `CacheManager`, passing in that configuration:
 
    ```java
-   Cache<String, MyObject> cache = new DefaultCache<>(config);
+   CacheManager manager = new DefaultCacheManager();
+   Cache<String, MyObject> cache = manager.createCache(config);
    ```
 
 3. Store and retrieve values:
@@ -37,11 +38,10 @@ Add the desired Ponder module(s) to your project by following the [Installation]
    MyObject value = cache.get("key");
    ```
 
-4. Manage multiple caches with `DefaultCacheManager`:
+4. Create additional caches from the same manager as needed:
 
    ```java
-   CacheManager manager = new DefaultCacheManager();
-   manager.addCache(cache);
+   Cache<String, OtherObject> otherCache = manager.createCache(new CacheConfiguration<>("other-cache"));
    ```
 
 ### Using ponder-commands
@@ -49,9 +49,9 @@ Add the desired Ponder module(s) to your project by following the [Installation]
 `ponder-commands` provides an abstraction layer for dispatching commands without coupling to a specific platform.
 
 1. Implement the `Command` interface for each command.
-2. Register commands with a `DefaultCommandService`.
-3. Dispatch incoming input through the service's `handle` method.
-4. Use `DelegatingCommand` to forward commands to sub-handlers.
+2. Register commands with a `DefaultCommandService` via `addCommand`.
+3. Look up a command by name with `getCommand` and call its `execute` method to run it.
+4. Use `DelegatingCommand` to route to sub-commands automatically based on the first argument.
 
 See the [API Reference](COMMANDS.md) for details on every interface and class.
 


### PR DESCRIPTION
## Summary

A documentation accuracy sweep (Phase 2 Stage A of the dev-loop) found several places where docs had drifted from the actual source in `ponder-cache`/`ponder-commands`, verified by reading the relevant `.java`/`.kt` files directly:

- `CONTRIBUTING.md` instructed contributors to branch from and PR against `develop`, but this repo has no `develop` branch (confirmed via `git branch -a` / `git ls-remote`) — only `main`.
- `USER_GUIDE.md` and `CONFIG.md` showed `new DefaultCache<>(config)`, but `DefaultCache`'s only constructor takes a `long capacity`, not a `CacheConfiguration` — this would not compile. The actual way to get a `Cache` from a `CacheConfiguration` is `CacheManager.createCache(config)`.
- `USER_GUIDE.md` referenced `CacheManager.addCache(cache)` and `CommandService.handle(...)`, neither of which exist on those interfaces (`CacheManager` only has `createCache(...)`; `CommandService` only has `addCommand`/`getCommand`).
- `COMMANDS.md` described `Args` as a wrapper class ("Wrapper around the raw argument string...") — it's actually free extension functions (`dropFirst()`, `unquote()`) on `Array<out String>`, with no `Args` type in the codebase.
- `COMMANDS.md` described `CommandService` as something that "accepts raw command input and dispatches it" — it's actually just a name→`Command` registry; dispatch/routing is `DelegatingCommand`'s job.
- `COMMANDS.md`'s `CacheManager`/`DefaultCacheManager` entries had no method table (unlike `Cache` and `CacheConfiguration` in the same file), so the corrected description now includes one matching sibling structure.

No production code changed — this is a docs-only PR (`ponder-bukkit`, `ponder-cache`, `ponder-commands` main sources are untouched).

No tracking issue — gaps found during a documentation accuracy sweep, not from the (currently empty, non-docs) open-issue backlog. The one open issue, #124 (Maven publishing), was left untouched — it requires changes to the `publishing { ... }` block and CI workflow, both of which need explicit human authorization per this repo's release-safety conventions, so it's out of scope for an autonomous docs cycle.

## Test plan

- [x] `./gradlew test` — `BUILD SUCCESSFUL`, all existing tests pass (docs-only change, used as the anchor per this repo's dev-loop convention since there's no dedicated build/test CI workflow)
- [x] Every corrected code example manually traced against the real method signatures in `ponder-cache`/`ponder-commands` source

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
