### PR TITLE
docs: correct CacheConfiguration field descriptions in CONFIG.md

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -14,7 +14,7 @@ Use `CacheConfiguration` to configure a `Cache` instance before constructing it.
 
 **Type:** `String`  
 **Required:** Yes  
-**Description:** A human-readable identifier for the cache. Used for logging and lookup via `CacheManager`.
+**Description:** A human-readable identifier for the cache. It is stored on the configuration but is not currently read by `DefaultCache` or `DefaultCacheManager` (no logging or lookup-by-name behavior yet).
 
 **Example:**
 
@@ -28,7 +28,7 @@ new CacheConfiguration<>("player-data");
 
 **Type:** `long`  
 **Default:** `20`  
-**Description:** The maximum number of entries the cache will hold. When capacity is reached, the oldest entry is evicted automatically.
+**Description:** The maximum number of entries the cache will hold. When capacity is exceeded, the least recently accessed entry is evicted automatically (an LRU policy — calling `get()` on an entry refreshes it and protects it from being the next eviction).
 
 **Example:**
 


### PR DESCRIPTION
## Summary

- `CONFIG.md`'s description of the `capacity` field was found to state that the *oldest* entry is evicted when capacity is exceeded. `DefaultCache.set()` was inspected and found to evict based on `lastAccess`, which is refreshed on every `get()` call — an LRU policy, not insertion-order eviction. The description was corrected to reflect this.
- `CONFIG.md`'s description of the `name` field was found to state that it is "used for logging and lookup via `CacheManager`". No such usage was found in `DefaultCache.java` or `DefaultCacheManager.java` — the value is stored on `CacheConfiguration` but never read elsewhere in the module. The description was corrected to reflect that it is currently inert.
- This is a Stage A (documentation accuracy sweep) cycle per the `ponder-dev-loop` skill; the only open backlog issue (#124, publish-to-Maven) was left untouched — it is CI/publishing-pipeline work that a prior autonomous PR (#125) attempted and was closed by the repo owner as requiring explicit human authorization, consistent with this skill's release-safety conventions. That deferral is recorded here rather than as a comment on #124, per the skill's guidance for externally-scoped/blocked backlog items.

## Test plan

- [x] `./gradlew test` — all three modules build and pass (`BUILD SUCCESSFUL`)
- [x] Both corrected claims verified directly against `ponder-cache/src/main/java/preponderous/ponder/cache/DefaultCache.java` and `DefaultCacheManager.java`
- [x] No source files changed — docs-only diff

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->