### PR TITLE
chore: release version 3.0.0-SNAPSHOT-8-8-2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [3.0.0-SNAPSHOT-8-8-2026] – 2026-08-08
+
+### Changed
+- Ponder is now developed AI-first. Day-to-day feature work, grooming, review and maintenance run through AI agents working directly against this repository, with the maintainers setting direction and approving what lands. The major version bump marks that change in how the project is built — it is not a break in behaviour, configuration or stored data, and existing installations can upgrade in place. Released as `3.0.0-SNAPSHOT-8-8-2026`: the AI-first line has not yet been verified in live operation, and the dated snapshot designation stays until it has.
 
 ## [2.0.0]
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ Add the DansPlugins repository and the desired module(s) to your `pom.xml`:
 <dependency>
     <groupId>com.dansplugins</groupId>
     <artifactId>ponder-bukkit</artifactId>
-    <version>2.0.0</version>
+    <version>3.0.0-SNAPSHOT-8-8-2026</version>
 </dependency>
 <dependency>
     <groupId>com.dansplugins</groupId>
     <artifactId>ponder-cache</artifactId>
-    <version>2.0.0</version>
+    <version>3.0.0-SNAPSHOT-8-8-2026</version>
 </dependency>
 <dependency>
     <groupId>com.dansplugins</groupId>
     <artifactId>ponder-commands</artifactId>
-    <version>2.0.0</version>
+    <version>3.0.0-SNAPSHOT-8-8-2026</version>
 </dependency>
 ```
 
@@ -72,9 +72,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.dansplugins:ponder-bukkit:2.0.0'
-    implementation 'com.dansplugins:ponder-cache:2.0.0'
-    implementation 'com.dansplugins:ponder-commands:2.0.0'
+    implementation 'com.dansplugins:ponder-bukkit:3.0.0-SNAPSHOT-8-8-2026'
+    implementation 'com.dansplugins:ponder-cache:3.0.0-SNAPSHOT-8-8-2026'
+    implementation 'com.dansplugins:ponder-commands:3.0.0-SNAPSHOT-8-8-2026'
 }
 ```
 

--- a/ponder-bukkit/build.gradle
+++ b/ponder-bukkit/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.dansplugins'
-version = "2.0.0"
+version = "3.0.0-SNAPSHOT-8-8-2026"
 
 def repoUsername = ""
 def repoPassword = ""

--- a/ponder-cache/build.gradle
+++ b/ponder-cache/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.dansplugins'
-version = "2.0.0"
+version = "3.0.0-SNAPSHOT-8-8-2026"
 
 def repoUsername = ""
 def repoPassword = ""

--- a/ponder-commands/build.gradle
+++ b/ponder-commands/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.dansplugins'
-version = "2.0.0"
+version = "3.0.0-SNAPSHOT-8-8-2026"
 
 def repoUsername = ""
 def repoPassword = ""


### PR DESCRIPTION
## Summary

The version has been bumped from `2.0.0` to `3.0.0-SNAPSHOT-8-8-2026` in `ponder-bukkit/build.gradle`, `ponder-cache/build.gradle`, `ponder-commands/build.gradle`.

The bump marks Ponder moving to an AI-first development approach: day-to-day feature work,
grooming, review and maintenance now run through AI agents working directly against this
repository, with the maintainers setting direction and approving what lands.

It is not a compatibility break. Behaviour, configuration and stored data are unchanged, and
existing installations can upgrade in place — the version marks a change in how the project is
built, not in what it does.

## Snapshot designation

The dated snapshot designation follows the precedent set by Medieval Factions'
`6.0.0-SNAPSHOT-7-25-2026`: the AI-first line has not yet been verified in live operation, and
the designation stays until it has.

## Notes

This is part of a garden-wide pass applying the same bump across every project tended by
Gardener. Only version metadata and the documentation that cites it has been changed; no functional code was touched.

---
*Drafted by Claude on behalf of Daniel Stephenson.*
