### PR TITLE
docs: correct API reference drift in COMMANDS.md

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -34,7 +34,11 @@ Immutable configuration for a `Cache` instance.
 
 ### `DefaultCache<K, V>`
 
-The standard `Cache` implementation backed by a `LinkedHashMap`. Accepts a `CacheConfiguration` at construction time.
+The standard `Cache` implementation, backed by a `ConcurrentHashMap`. Its constructor takes a `long capacity` rather than a `CacheConfiguration` — `DefaultCacheManager` reads the capacity off a configuration and passes it through. Once the entry count exceeds the capacity, the least recently accessed entry is evicted on each `set`.
+
+| Constructor | Description |
+|-------------|-------------|
+| `DefaultCache(long capacity)` | Creates a cache holding at most `capacity` entries. |
 
 ### `CacheManager` (interface)
 
@@ -53,9 +57,13 @@ The standard `CacheManager` implementation.
 
 ## ponder-commands
 
-### `Command` (interface)
+### `Command` (functional interface)
 
-Represents a single executable command.
+Represents a single executable command. Being a Kotlin `fun interface`, it can be implemented with a lambda.
+
+| Method | Description |
+|--------|-------------|
+| `suspend execute(CommandSender sender, vararg String args)` | Runs the command on behalf of the sender and returns a `CommandResult`. Suspending, so it must be called from a coroutine. |
 
 ### `CommandSender` (interface)
 
@@ -70,13 +78,18 @@ Extension functions on `Array<out String>` for working with raw command argument
 | `Array<out String>.dropFirst()` | Returns a new array with the first element removed. |
 | `Array<out String>.unquote()` | Merges quoted, space-separated arguments (e.g. `"hello world"`) back into single elements. |
 
-### `CommandResult` (sealed class / interface)
+### `CommandResult` (sealed interface)
 
-Represents the outcome of executing a command.
+Represents the outcome of executing a command. Two implementations ship in the same file.
+
+| Member | Description |
+|--------|-------------|
+| `CommandSuccess` (object) | Singleton indicating the command completed successfully. |
+| `CommandFailure` (open class) | Base type for failures. Being `open`, it can be subclassed to describe a specific failure. |
 
 ### `IncorrectUsageFailure`
 
-A `CommandResult` subtype indicating that the command was invoked with invalid arguments.
+A `CommandFailure` subtype indicating that the command was invoked with invalid arguments.
 
 ### `CommandService` (interface)
 
@@ -93,24 +106,45 @@ The standard `CommandService` implementation.
 
 ### `DelegatingCommand`
 
-A `Command` that forwards execution to a child command based on the first argument (sub-command routing).
+A `Command` that forwards execution to a sub-command selected by the first argument (sub-command routing). It also implements `CommandService`, so its sub-commands can be added and looked up after construction.
+
+| Member | Description |
+|--------|-------------|
+| `DelegatingCommand(Map<String, Command> subcommands, String usageMessage)` | Creates a delegating command over a copy of the given sub-command map. |
+| `suspend execute(CommandSender sender, vararg String args)` | Strips the first argument and runs the matching sub-command with the remainder. When the arguments are empty or no sub-command matches, `usageMessage` is sent to the sender and an `IncorrectUsageFailure` is returned. |
+| `addCommand(String name, Command command)` | Registers a sub-command under the given name. |
+| `getCommand(String name)` | Returns the sub-command registered under the given name, or `null`. |
 
 ---
 
 ## ponder-bukkit
 
-All members are Kotlin extension functions/properties in the `preponderous.ponder.minecraft.bukkit` packages.
+Members live in the `preponderous.ponder.minecraft.bukkit` packages and are, apart from the `Distance` value class itself, Kotlin extension functions and properties.
 
 ### Distance utilities (`distance` package)
 
 | Member | Description |
 |--------|-------------|
 | `Distance` (value class) | Wraps a `Double` representing a block distance. |
+| `Distance.valueSquared` | The wrapped value multiplied by itself, so comparisons can avoid a square root. |
 | `Int.blocks` | Converts an `Int` to a `Distance`. |
 | `Double.blocks` | Converts a `Double` to a `Distance`. |
-| `location within distance` (infix) | Returns a `Predicate<Location>` that matches locations within the given distance. Usage: `location within 10.blocks`. |
-| `player within distance` (infix) | Returns a `Predicate<Player>` that matches players within the given distance. Usage: `player within 10.blocks`. |
+| `location within distance` (infix) | Returns a `Predicate<Location>` matching locations within the given distance of the receiver. |
+| `player within distance` (infix) | Returns a `Predicate<Player>` matching players within the given distance of the receiver. |
+| `predicate of value` (infix) | Applies a `Predicate<T>` to a value and returns the `Boolean` result. |
 | `Player.findPlayersWithin(distance)` | Returns all players in the same world within the given distance, excluding the receiver. |
+
+The `within` functions return a `Predicate` rather than a `Boolean`, so a comparison is written by applying that predicate with `of`. Both infix functions have the same precedence and associate to the left, so no parentheses are needed:
+
+```kotlin
+if (playerA within 10.blocks of playerB) {
+    // ...
+}
+
+if (someLocation within 5.blocks of anotherLocation) {
+    // ...
+}
+```
 
 ### Plugin utilities (`plugin` package)
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ If you see `BUILD SUCCESSFUL`, the tests have passed.
 
 ## Development
 
-### Test Server with Plugin Hot-Reloading
+### Manual Integration Testing
 
-For manual integration testing, build the project and deploy the JARs to a local Spigot server.
+Ponder is a library rather than a plugin, so it is exercised on a server through a plugin that depends on it. For manual integration testing, build the project, install the JARs into the dependent plugin's build, and run that plugin on a local Spigot server. No test server or hot-reloading tooling is provided by this repository.
 
 #### Building
 


### PR DESCRIPTION
## Summary

A documentation accuracy sweep was run across this repository's documentation sources of truth (`README.md`, `COMMANDS.md`, `CONFIG.md`, `USER_GUIDE.md`, `CONTRIBUTING.md`), with every claim checked against the source it describes. `CONFIG.md`, `USER_GUIDE.md` and `CONTRIBUTING.md` were found accurate and are untouched. The drift found in `COMMANDS.md` and `README.md` is corrected here.

**`ponder-cache`**

- `DefaultCache` was described as backed by a `LinkedHashMap`; it is backed by a `ConcurrentHashMap`.
- `DefaultCache` was described as accepting a `CacheConfiguration` at construction time; its only constructor takes a `long capacity`, which `DefaultCacheManager` reads off the configuration before constructing the cache. A constructor table was added, matching the one `CacheConfiguration` already carries.

**`ponder-commands`**

- `CommandResult` was labelled a "sealed class / interface"; it is a `sealed interface`. Its two shipped implementations, `CommandSuccess` and `CommandFailure`, were undocumented and are now listed.
- `IncorrectUsageFailure` was described as a `CommandResult` subtype; it extends `CommandFailure` specifically.
- `Command` carried no method table while its sibling entries do. It is a `fun interface` whose single member is a suspending `execute`, which is now documented.
- `DelegatingCommand` was documented as a `Command` only. It also implements `CommandService`, and it sends the configured usage message and returns `IncorrectUsageFailure` when the arguments are empty or no sub-command matches.

**`ponder-bukkit`**

- The section opened with "All members are Kotlin extension functions/properties", which the `Distance` value class in the table immediately below contradicts.
- `Distance.valueSquared` and the `Predicate<T>.of` infix function are public and were undocumented.
- The usage examples given for the `within` infix functions (`location within 10.blocks`) were incomplete: those functions return a `Predicate`, which is applied with `of`. Runnable examples replace them.

**`README.md`**

- The heading "Test Server with Plugin Hot-Reloading" promised tooling this repository does not contain — the section beneath it describes building JARs and deploying them by hand. It has been renamed, and its text now says how a library, as opposed to a plugin, is exercised on a server.

## Test plan

- [x] `./gradlew test` — BUILD SUCCESSFUL (9 tasks, all three modules), run before and after the change
- [x] Every corrected claim traced to a specific line of source rather than to recollection
- [x] Diff confined to two documentation files; no source, `build.gradle`, `settings.gradle`, or workflow file is touched
- [x] No module version, `group`, or `publishing` block is modified — no release decision is implied by this PR

## Deferred work

The rest of the open backlog was left untouched this cycle, with reasons recorded:

- #124 (publishing to the dansplugins.com Maven repository) — already configured in all three modules; a comment recording the current state was left on the issue. The remaining problem is credentials, split out as #131.
- #131 (the `Publish Packages to GitHub` workflow failing on every run with a 401 from `repo.dansplugins.com`) — filed during this cycle's triage. Its fix sites are `.github/workflows/publish-packages.yml` and the module `publishing` blocks, both on this repository's do-not-auto-merge list, and a maintainer decision between the options laid out in that issue is wanted first.
- #132 (empty, unreferenced `compile.sh` at the repository root) — filed during this cycle's triage. Deleting a tracked file is a code change, not a documentation correction, so it was kept out of this sweep.

Closes #130

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

---

_drafted by Claude on behalf of Daniel Stephenson_